### PR TITLE
chore: publish to @minddoc npm org

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,8 +10,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "13.x"
-          registry-url: "https://npm.pkg.github.com"
-          scope: "@minddocdev"
+          scope: "@minddoc"
       - name: Install yarn dependencies
         run: yarn install --frozen-lockfile
       - name: Lint code

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ yarn test
 ## Installation
 
 ```bash
-yarn add @minddocdev/nest-express-winston
+yarn add @minddoc/nest-express-winston
 ```
 
 If it does not exist, add a `.yarnrc` file to the root of your project with the following content:
 
 ```text
-"@minddocdev:registry" "https://npm.pkg.github.com"
+"@minddoc:registry" "https://npm.pkg.github.com"
 ```
 
 Ensure you are logged in to github using a personal access token with
@@ -51,7 +51,7 @@ import {
   createNestWinstonLogger,
   httpContextMiddleware,
   requestIdHandler,
-} from '@minddocdev/nest-express-winston';
+} from '@minddoc/nest-express-winston';
 ```
 
 ### Basic Example
@@ -72,7 +72,7 @@ import {
   createNestWinstonLogger,
   httpContextMiddleware,
   requestIdHandler,
-} from '@minddocdev/nest-express-winston';
+} from '@minddoc/nest-express-winston';
 
 import { AppModule } from './app.module';
 import { EnvService } from './env';

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@minddocdev/nest-express-winston",
+  "name": "@minddoc/nest-express-winston",
   "version": "0.2.0",
   "description": "Implementation of a nestjs logger using winston and express-winston",
   "author": "MindDoc Health GmbH",
@@ -18,9 +18,6 @@
     "type": "git",
     "url": "https://github.com/minddocdev/nest-express-winston.git"
   },
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
-  },
   "keywords": [
     "nestjs",
     "node",
@@ -31,7 +28,8 @@
     "build": "tsc -b -v",
     "test": "yarn build && jest --coverage --verbose --no-cache",
     "lint": "tslint --project .",
-    "ncu:u": "ncu -u"
+    "ncu:u": "ncu -u",
+    "publish": "npm publish . --access public"
   },
   "dependencies": {
     "@nestjs/common": "~7.4.4",


### PR DESCRIPTION
Publish to the @minddoc npm organization.

After merge and publish, refactor all internal @minddocdev references!